### PR TITLE
[HER-62] Add rxjs and redux-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "react-picture-grid": "1.0.41",
     "react-redux": "7.2.4",
     "react-router-dom": "5.2.0",
-    "react-scripts": "4.0.3"
+    "react-scripts": "4.0.3",
+    "redux-devtools-extension": "2.13.9",
+    "redux-observable": "2.0.0",
+    "rxjs": "7.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { Provider } from 'react-redux'
 
 import { Router } from 'startup/router'
-import { createStore } from 'startup/create-store'
+import { configureStore } from 'startup/create-store'
 
-export const App = () => <Provider store={createStore()}>
+export const App = () => <Provider store={configureStore()}>
   <Router />
 </Provider>

--- a/src/startup/create-store.js
+++ b/src/startup/create-store.js
@@ -1,5 +1,15 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { applyMiddleware, createStore } from '@reduxjs/toolkit'
+import { createEpicMiddleware } from 'redux-observable'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 import { rootReducer } from 'startup/root-reducer'
+import { rootEpic } from 'startup/root-epic'
 
-export const createStore = () => configureStore({ reducer: rootReducer })
+const epicMiddleware = createEpicMiddleware()
+
+export const configureStore = () => {
+  const store = createStore(rootReducer, composeWithDevTools(applyMiddleware(epicMiddleware)))
+  epicMiddleware.run(rootEpic)
+
+  return store
+}

--- a/src/startup/root-epic.js
+++ b/src/startup/root-epic.js
@@ -1,0 +1,3 @@
+import { combineEpics } from 'redux-observable'
+
+export const rootEpic = combineEpics()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.3.21":
+"@apollo/client@3.3.21":
   version "3.3.21"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.21.tgz#2862baa4e1ced8c5e89ebe6fc52877fc64a726aa"
   integrity sha512-RAmZReFuKCKx0Rs5C0nVJwKomAHUHn+gGP/YvbEsXQWu0sXoncEUZa71UqlfCPVXa/0MkYOIbCXSQdOcuRrHgw==
@@ -5596,7 +5596,7 @@ graphql-tag@^2.12.0:
   dependencies:
     tslib "^2.1.0"
 
-graphql@^15.5.1:
+graphql@15.5.1:
   version "15.5.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
   integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
@@ -9803,6 +9803,19 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
+redux-devtools-extension@^2.13.9:
+  version "2.13.9"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz#6b764e8028b507adcb75a1cae790f71e6be08ae7"
+  integrity sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==
+
+redux-observable@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-2.0.0.tgz#4358bef2e924723a8b1ad0e835ccebb1612a6b9a"
+  integrity sha512-FJz4rLXX+VmDDwZS/LpvQsKnSanDOe8UVjiLryx1g3seZiS69iLpMrcvXD5oFO7rtkPyRdo/FmTqldnT3X3m+w==
+  dependencies:
+    rxjs "^7.0.0"
+    tslib "~2.1.0"
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
@@ -10184,6 +10197,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rxjs@7.2.0, rxjs@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.2.0.tgz#5cd12409639e9514a71c9f5f9192b2c4ae94de31"
+  integrity sha512-aX8w9OpKrQmiPKfT1bqETtUr9JygIz6GZ+gql8v7CijClsP0laoFUdKzxFAoWuRdSlOdU2+crss+cMf+cqMTnw==
+  dependencies:
+    tslib "~2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -11279,7 +11299,7 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==


### PR DESCRIPTION
## Description
Install the `rxjs` and `redux-observable` npm packages and change the redux store config to accommodate the usage of epics. 

## Related
[HER-62](https://nerds-interns.atlassian.net/jira/software/projects/HER/boards/1?selectedIssue=HER-62)